### PR TITLE
Fix GitHub Action to post formatting updates to PR

### DIFF
--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
 
     - name: Install dependencies
       run: npm install
@@ -38,7 +38,7 @@ jobs:
           const output = execSync('npx prettier --write .', { encoding: 'utf-8' });
           const comment = `### Prettier Formatting Fixes\n\`\`\`\n${output}\n\`\`\``;
           github.rest.issues.createComment({
-            issue_number: context.issue.number,
+            issue_number: context.payload.pull_request.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: comment


### PR DESCRIPTION
Fixes #5

Update the GitHub Action to fix the TypeError related to 'issues' when posting formatting updates to the pull request.

* **Update dependencies**
  - Change `actions/checkout@v2` to `actions/checkout@v4`.
  - Change `actions/setup-node@v2` to `actions/setup-node@v3`.
  - Update `node-version` to '16' in the `with` block.

* **Fix TypeError**
  - Update `context.issue.number` to `context.payload.pull_request.number` in the script block to ensure the correct issue number is used.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher/issues/5?shareId=cd446992-5798-47b8-ac95-02ec6f186aac).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the GitHub Action for posting formatting updates by updating dependencies and correcting the issue number reference to resolve a TypeError.

CI:
- Update GitHub Action dependencies to use `actions/checkout@v4` and `actions/setup-node@v3`.
- Change Node.js version to 16 in the GitHub Action configuration.
- Fix TypeError by updating the script to use `context.payload.pull_request.number` for the correct issue number.

<!-- Generated by sourcery-ai[bot]: end summary -->