### PR TITLE
Fix GitHub script error in formatting check workflow

### DIFF
--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -28,15 +28,4 @@ jobs:
 
     - name: Comment on pull request with fixed formatting
       if: failure()
-      uses: actions/github-script@v3
-      with:
-        script: |
-          const { execSync } = require('child_process');
-          const output = execSync('npx prettier --write .', { encoding: 'utf-8' });
-          const comment = `### Prettier Formatting Fixes\n\`\`\`\n${output}\n\`\`\``;
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: comment
-          });
+      run: gh pr comment ${{ github.event.pull_request.number }} --body "### Prettier Formatting Fixes\n\`\`\`\n$(npx prettier --write .)\n\`\`\`"

--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -28,4 +28,8 @@ jobs:
 
     - name: Comment on pull request with fixed formatting
       if: failure()
-      run: gh pr comment ${{ github.event.pull_request.number }} --body "### Prettier Formatting Fixes\n\`\`\`\n$(npx prettier --write .)\n\`\`\`"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        npx prettier --write .
+        gh pr comment ${{ github.event.pull_request.number }} --body "### Prettier Formatting Fixes\n\`\`\`\n$(npx prettier --write .)\n\`\`\`"


### PR DESCRIPTION
Update the `formatting-check.yml` workflow to use GitHub CLI for posting comments on pull requests.

* Replace the `actions/github-script@v3` action with a GitHub CLI command to post a comment on the pull request.
* Ensure the GitHub CLI command includes the necessary parameters for posting a comment with Prettier formatting fixes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher?shareId=babaff68-9d6a-40c6-a84f-96807b638e1c).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replace the GitHub script action with a GitHub CLI command in the formatting check workflow to post comments on pull requests with Prettier formatting fixes.

CI:
- Update the `formatting-check.yml` workflow to replace the `actions/github-script@v3` action with a GitHub CLI command for posting comments on pull requests.

<!-- Generated by sourcery-ai[bot]: end summary -->