### PR TITLE
Update pritter to 120

### DIFF
--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -28,7 +28,8 @@ jobs:
 
     - name: Comment on pull request with fixed formatting
       if: failure()
-      uses: reviewdog/action-suggester@v1
-      with:
-        tool_name: prettier
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        npx prettier --write .
+        gh pr comment ${{ github.event.pull_request.number }} --body "### Prettier Formatting Fixes\n\`\`\`\n$(npx prettier --write .)\n\`\`\`"

--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -28,8 +28,7 @@ jobs:
 
     - name: Comment on pull request with fixed formatting
       if: failure()
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        npx prettier --write .
-        gh pr comment ${{ github.event.pull_request.number }} --body "### Prettier Formatting Fixes\n\`\`\`\n$(npx prettier --write .)\n\`\`\`"
+      uses: reviewdog/action-suggester@v1
+      with:
+        tool_name: prettier
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/extension/.prettierrc
+++ b/extension/.prettierrc
@@ -2,5 +2,6 @@
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "printWidth": 80
 }

--- a/extension/.prettierrc
+++ b/extension/.prettierrc
@@ -3,5 +3,5 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "printWidth": 80
+  "printWidth": 120
 }


### PR DESCRIPTION
Update the formatting check workflow to use reviewdog action-suggester for Prettier.

* **extension/.prettierrc**
  - Add `"printWidth": 80` to the Prettier configuration.

* **.github/workflows/formatting-check.yml**
  - Replace the manual comment on pull request with reviewdog action-suggester.
  - Use `reviewdog/action-suggester@v1` with `tool_name: prettier` and `github_token: ${{ secrets.GITHUB_TOKEN }}`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher?shareId=4b646fca-a5ab-4114-a48d-63ff7cb69dea).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Integrate reviewdog action-suggester into the formatting check workflow for Prettier, replacing the manual comment process, and update the Prettier configuration with a print width setting.

Enhancements:
- Add 'printWidth: 80' to the Prettier configuration in the .prettierrc file.

CI:
- Update the formatting check workflow to use reviewdog action-suggester for Prettier, replacing the manual comment on pull requests.

<!-- Generated by sourcery-ai[bot]: end summary -->