### PR TITLE
Fix account switcher issue

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -3,11 +3,37 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 function switchAccountIfNecessary(tabId) {
-  chrome.tabs.executeScript(tabId, { file: 'content.js' });
+  chrome.tabs.executeScript(tabId, { file: 'content.js' }, () => {
+    chrome.tabs.sendMessage(tabId, { action: 'verifyAccountSwitch' }, (response) => {
+      if (!response.success) {
+        setTimeout(() => switchAccountIfNecessary(tabId), 1000);
+      }
+    });
+  });
+}
+
+function isEnterpriseUrl(url) {
+  return url.includes('github.mycompany.com');
+}
+
+function isPrivateGithubUrl(url) {
+  return url.includes('github.com');
+}
+
+function detectRepositoryType(url) {
+  if (isEnterpriseUrl(url)) {
+    return 'enterprise';
+  } else if (isPrivateGithubUrl(url)) {
+    return 'private';
+  }
+  return 'unknown';
 }
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status === 'complete' && tab.url.includes('github.com')) {
-    switchAccountIfNecessary(tabId);
+  if (changeInfo.status === 'complete') {
+    const repositoryType = detectRepositoryType(tab.url);
+    if (repositoryType === 'enterprise' || repositoryType === 'private') {
+      switchAccountIfNecessary(tabId);
+    }
   }
 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -19,6 +19,13 @@ function selectCorrectAccount() {
   }
 }
 
+function handleRepositoryTransition() {
+  const currentUrl = window.location.href;
+  if (isEnterpriseUrl(currentUrl) || isPrivateGithubUrl(currentUrl)) {
+    selectCorrectAccount();
+  }
+}
+
 const debounce = (func, delay) => {
   let timeoutId;
   return (...args) => {
@@ -46,4 +53,5 @@ if (headerElement) {
 
 window.addEventListener('load', () => {
   debouncedSelectCorrectAccount();
+  handleRepositoryTransition();
 });


### PR DESCRIPTION
Fixes #11

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher/issues/11?shareId=2a557e9c-48db-49b5-9089-91c4da892ed1).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the account switcher issue by implementing a mechanism to verify account switching success and retry if necessary. Enhance the extension by detecting the type of GitHub repository and ensuring the correct account is selected during repository transitions.

Bug Fixes:
- Fix the account switcher issue by ensuring the correct account is selected when navigating between different types of GitHub repositories.

Enhancements:
- Add functions to detect the type of GitHub repository (enterprise or private) based on the URL.

<!-- Generated by sourcery-ai[bot]: end summary -->