### PR TITLE
Fix duplicate declaration of detectAccountPicker

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -5,7 +5,8 @@ chrome.runtime.onInstalled.addListener(() => {
 function switchAccountIfNecessary(tabId) {
   chrome.scripting.executeScript({
     target: { tabId: tabId },
-    files: ['content.js']
+    files: ['content.js'],
+    world: 'MAIN'
   });
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,49 +1,51 @@
-const detectAccountPicker = () => {
-  return document.querySelector('.Header-link .dropdown-menu');
-};
+(() => {
+  const detectAccountPicker = () => {
+    return document.querySelector('.Header-link .dropdown-menu');
+  };
 
-const selectCorrectAccount = () => {
-  try {
-    const accountPicker = detectAccountPicker();
-    if (accountPicker) {
-      const accounts = accountPicker.querySelectorAll('a');
-      for (let i = 0; i < accounts.length; i++) {
-        if (accounts[i].dataset.accountId === config.correctAccountId) {
-          accounts[i].click();
-          break;
+  const selectCorrectAccount = () => {
+    try {
+      const accountPicker = detectAccountPicker();
+      if (accountPicker) {
+        const accounts = accountPicker.querySelectorAll('a');
+        for (let i = 0; i < accounts.length; i++) {
+          if (accounts[i].dataset.accountId === config.correctAccountId) {
+            accounts[i].click();
+            break;
+          }
         }
       }
+    } catch (error) {
+      console.error('Error selecting the correct account:', error);
     }
-  } catch (error) {
-    console.error('Error selecting the correct account:', error);
-  }
-};
-
-const debounceAccountSelector = (func, delay) => {
-  let timeoutId;
-  return (...args) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => func(...args), delay);
   };
-};
 
-const debouncedSelectCorrectAccount = debounceAccountSelector(selectCorrectAccount, 100);
+  const debounceAccountSelector = (func, delay) => {
+    let timeoutId;
+    return (...args) => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => func(...args), delay);
+    };
+  };
 
-const observer = new MutationObserver((mutations) => {
-  if (detectAccountPicker()) {
-    debouncedSelectCorrectAccount();
-    observer.disconnect(); // Stop observing once account is selected
+  const debouncedSelectCorrectAccount = debounceAccountSelector(selectCorrectAccount, 100);
+
+  const observer = new MutationObserver((mutations) => {
+    if (detectAccountPicker()) {
+      debouncedSelectCorrectAccount();
+      observer.disconnect(); // Stop observing once account is selected
+    }
+  });
+
+  const headerElement = document.querySelector('.Header-link');
+  if (headerElement) {
+    observer.observe(headerElement, { childList: true, subtree: true });
+  } else {
+    // Fall back to observing body if header is not found
+    observer.observe(document.body, { childList: true, subtree: true });
   }
-});
 
-const headerElement = document.querySelector('.Header-link');
-if (headerElement) {
-  observer.observe(headerElement, { childList: true, subtree: true });
-} else {
-  // Fall back to observing body if header is not found
-  observer.observe(document.body, { childList: true, subtree: true });
-}
-
-window.addEventListener('load', () => {
-  debouncedSelectCorrectAccount();
-});
+  window.addEventListener('load', () => {
+    debouncedSelectCorrectAccount();
+  });
+})();

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,4 +1,4 @@
-document.getElementById('switchAccountButton').addEventListener('click', () => {
+(() => {
   const selectCorrectAccount = () => {
     try {
       const accountPicker = document.querySelector('.Header-link .dropdown-menu');
@@ -14,7 +14,13 @@ document.getElementById('switchAccountButton').addEventListener('click', () => {
     } catch (error) {
       console.error('Error selecting the correct account:', error);
     }
-  }
+  };
 
-  selectCorrectAccount();
-});
+  document.getElementById('switchAccountButton').addEventListener('click', () => {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: selectCorrectAccount,
+      world: 'MAIN'
+    });
+  });
+})();


### PR DESCRIPTION
Fixes #25

Address the "Uncaught SyntaxError: Identifier 'detectAccountPicker' has already been declared" error by wrapping scripts in IIFEs and updating script execution context.

* **extension/background.js**
  - Update `switchAccountIfNecessary` function to use `chrome.scripting.executeScript` with `world: 'MAIN'` option.

* **extension/content.js**
  - Wrap the entire content script in an IIFE (Immediately Invoked Function Expression).

* **extension/popup.js**
  - Wrap the entire script in an IIFE (Immediately Invoked Function Expression).
  - Move the `selectCorrectAccount` function outside the event listener.
  - Update the `selectCorrectAccount` function to use `chrome.scripting.executeScript` with `world: 'MAIN'` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher/issues/25?shareId=b87bb8bd-07f4-463a-b12f-c30d98ded08a).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Wrap scripts in IIFEs to prevent duplicate declarations and update script execution context to fix syntax errors and improve script execution.

Bug Fixes:
- Fix the 'Uncaught SyntaxError: Identifier 'detectAccountPicker' has already been declared' error by wrapping scripts in Immediately Invoked Function Expressions (IIFEs).

Enhancements:
- Update the `switchAccountIfNecessary` function in `background.js` to use `chrome.scripting.executeScript` with the `world: 'MAIN'` option.
- Move the `selectCorrectAccount` function outside the event listener in `popup.js` and update it to use `chrome.scripting.executeScript` with the `world: 'MAIN'` option.

<!-- Generated by sourcery-ai[bot]: end summary -->