### PR TITLE
Automatically select 'Switch to another account' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 GitHub Account Switcher is a Chrome extension that automatically selects the appropriate GitHub account when accessing a repository. It determines the correct account based on predefined rules or patterns, such as repository ownership or organization membership. This extension streamlines workflow for users with multiple GitHub accounts, eliminating the need for manual account switching.
 
+### New Feature: Automatically Select "Switch to another account" Option
+
+The extension now includes a feature that automatically selects the "Switch to another account" option when the "Signed in as" tab pops up. This ensures a seamless transition for users who need to switch accounts.
+
 ## Manual Installation
 
 1. Clone the repository to your local machine.
@@ -16,3 +20,4 @@ GitHub Account Switcher is a Chrome extension that automatically selects the app
 1. Open GitHub and navigate to a repository where you have multiple accounts.
 2. The extension should automatically switch to the correct account if the current account does not have access.
 3. If the extension does not work as expected, check the console for any error messages and ensure that the `background.js` and `content.js` files are correctly loaded.
+4. Verify that the extension automatically selects the "Switch to another account" option when the "Signed in as" tab pops up.

--- a/extension/background.js
+++ b/extension/background.js
@@ -34,6 +34,14 @@ function ensureAccountSwitch() {
         }
       }
     }
+    selectSwitchToAnotherAccountOption();
+  }
+}
+
+function selectSwitchToAnotherAccountOption() {
+  const switchAccountOption = document.querySelector('a[href*="switch-to-another-account"]');
+  if (switchAccountOption) {
+    switchAccountOption.click();
   }
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -25,9 +25,17 @@
             }
           }
         }
+        selectSwitchToAnotherAccountOption();
       }
     } catch (error) {
       console.error('Error selecting the correct account:', error);
+    }
+  };
+
+  const selectSwitchToAnotherAccountOption = () => {
+    const switchAccountOption = document.querySelector('a[href*="switch-to-another-account"]');
+    if (switchAccountOption) {
+      switchAccountOption.click();
     }
   };
 


### PR DESCRIPTION
Fixes #28

Update the extension to automatically select the "Switch to another account" option when the "Signed in as" tab pops up.

* **extension/background.js**
  - Update `ensureAccountSwitch` function to call `selectSwitchToAnotherAccountOption`.
  - Add new function `selectSwitchToAnotherAccountOption` to handle the selection of the "Switch to another account" option.

* **extension/content.js**
  - Update `selectCorrectAccount` function to call `selectSwitchToAnotherAccountOption`.
  - Add new function `selectSwitchToAnotherAccountOption` to handle the selection of the "Switch to another account" option.

* **README.md**
  - Add a new section under "Description" to explain the new feature of automatically selecting the "Switch to another account" option.
  - Add a new step under "Testing" to verify the new feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher/issues/28?shareId=f05efc6b-6501-4ca6-9b70-92cb885b14a4).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement automatic selection of the 'Switch to another account' option in the extension to improve account management for users with multiple GitHub accounts. Update documentation to reflect this new feature and provide guidance on testing it.

New Features:
- Introduce a feature that automatically selects the 'Switch to another account' option when the 'Signed in as' tab appears, enhancing user experience for those managing multiple accounts.

Documentation:
- Update README.md to include a description of the new feature that automatically selects the 'Switch to another account' option and add a testing step to verify this functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->