### PR TITLE
Fix bug in account switcher

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -7,7 +7,23 @@
     return window.location.hostname !== 'github.com';
   };
 
-  const selectCorrectAccount = () => {
+  const waitForElement = (selector, timeout = 5000) => {
+    return new Promise((resolve, reject) => {
+      const observer = new MutationObserver(() => {
+        if (document.querySelector(selector)) {
+          observer.disconnect();
+          resolve();
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Timeout waiting for ${selector}`));
+      }, timeout);
+    });
+  };
+
+  const selectCorrectAccount = async () => {
     try {
       const accountPicker = detectAccountPicker();
       if (accountPicker) {
@@ -25,6 +41,7 @@
             }
           }
         }
+        await waitForElement('.switch-account-option');
         selectSwitchToAnotherAccountOption();
       }
     } catch (error) {


### PR DESCRIPTION
Fixes #30

Add a delay and use MutationObserver before calling `selectSwitchToAnotherAccountOption()`.

* **Add `waitForElement` function**: 
  - Waits for the presence of the `.switch-account-option` element.
  - Uses a `MutationObserver` to monitor the DOM for the presence of the element.
  - Sets a timeout to reject the promise if the element is not found within the specified time.

* **Update `selectCorrectAccount` function**:
  - Makes the function asynchronous.
  - Calls `waitForElement` before calling `selectSwitchToAnotherAccountOption()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/github-account-switcher/issues/30?shareId=9e6efb52-48d0-4625-abf3-3c9e713550c1).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the account switcher bug by implementing a waitForElement function that uses a MutationObserver to ensure the presence of the switch account option before selection, and update the selectCorrectAccount function to be asynchronous.

Bug Fixes:
- Fix the account switcher bug by adding a delay and using a MutationObserver to ensure the presence of the switch account option before attempting to select it.

Enhancements:
- Introduce the waitForElement function to monitor the DOM for specific elements using a MutationObserver and handle timeouts.

<!-- Generated by sourcery-ai[bot]: end summary -->